### PR TITLE
Compatibility with gmusicapi 1.0.0

### DIFF
--- a/rhythmbox_gmusic.egg-info/PKG-INFO
+++ b/rhythmbox_gmusic.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: rhythmbox-gmusic
-Version: 2.0dev
+Version: 4.0dev
 Summary: Rhythmbox Google Play Music Plugin
 Home-page: https://github.com/nvbn/rhythmbox-gmusic/
 Author: Vladimir Iakovlev

--- a/rhythmbox_gmusic.egg-info/requires.txt
+++ b/rhythmbox_gmusic.egg-info/requires.txt
@@ -1,1 +1,2 @@
 gmusicapi
+futures

--- a/rhythmboxgmusic/__init__.py
+++ b/rhythmboxgmusic/__init__.py
@@ -1,6 +1,6 @@
 from gi.repository import GObject, Peas, Gtk, GConf, RB, GLib, GnomeKeyring
 from concurrent import futures
-from gmusicapi.api import Api
+from gmusicapi import Webclient as Api
 from gettext import lgettext as _
 import gettext
 import rb
@@ -282,7 +282,7 @@ class GBaseSource(RB.Source):
         if api.is_authenticated():
             return True
         login, password = get_credentials()
-        return api.login(login, password, perform_upload_auth=False)
+        return api.login(login, password)
 
     def auth(self, widget):
         dialog = AuthDialog()

--- a/rhythmboxgmusic/__init__.py
+++ b/rhythmboxgmusic/__init__.py
@@ -17,7 +17,7 @@ except TypeError:
     # for newer version
     api = Api()
 
-executor = futures.ProcessPoolExecutor(max_workers=1)
+executor = futures.ThreadPoolExecutor(max_workers=1)
 settings = GConf.Client.get_default()
 
 LOGIN_KEY = 'login'


### PR DESCRIPTION
Version 1.0.0 of gmusicapi introduced Webclient and Musicmanager as replacement for Api.

Additionally I had to replace futures.ProcessPoolExecuter with futures.ThreadPoolExecuter due to SSL errors in requests-package used by gmusicapi, which occur if the api is called from a different process.
