### PR TITLE
Closing issue #28 due to changes on gmusicapi

### DIFF
--- a/rhythmboxgmusic/__init__.py
+++ b/rhythmboxgmusic/__init__.py
@@ -98,7 +98,7 @@ class GEntry(RB.RhythmDBEntryType):
 
     def do_get_playback_uri(self, entry):
         id = entry.dup_string(RB.RhythmDBPropType.LOCATION).split('/')[1]
-        return api.get_stream_url(id)
+        return api.get_stream_urls(id)
 
     def do_can_sync_metadata(self, entry):
         return True

--- a/rhythmboxgmusic/__init__.py
+++ b/rhythmboxgmusic/__init__.py
@@ -98,7 +98,7 @@ class GEntry(RB.RhythmDBEntryType):
 
     def do_get_playback_uri(self, entry):
         id = entry.dup_string(RB.RhythmDBPropType.LOCATION).split('/')[1]
-        return api.get_stream_urls(id)
+        return api.get_stream_urls(id)[0]
 
     def do_can_sync_metadata(self, entry):
         return True


### PR DESCRIPTION
The gmusicapi has changed its "get_stream_url" method with a "get_stream_urls", that returns all the stream urls available for a song.

This pull request uses the right call, avoiding an error shown in the terminal and pick de first element of the retrieved list of URLs to get some sound for the plugin.

Best regards
