### PR TITLE
BUGFIX: don't mix static and introspected APIs

### DIFF
--- a/rhythmboxgmusic/__init__.py
+++ b/rhythmboxgmusic/__init__.py
@@ -5,7 +5,6 @@ from gmusicapi import Webclient as Api
 from gmusicapi import Mobileclient as Mapi
 from gettext import lgettext as _
 import gettext
-import rb
 import json
 import os.path
 import logging
@@ -76,7 +75,7 @@ class GooglePlayMusic(GObject.Object, Peas.Activatable):
         model = RB.RhythmDBQueryModel.new_empty(db)
         theme = Gtk.IconTheme.get_default()
         what, width, height = Gtk.icon_size_lookup(Gtk.IconSize.LARGE_TOOLBAR)
-        icon = rb.try_load_icon(theme, "media-playback-start", width, 0)
+        icon = RB.try_load_icon(theme, "media-playback-start", width, 0)
         self.source = GObject.new(
             GooglePlayLibrary, shell=shell,
             name="Google Play Music",


### PR DESCRIPTION
- the rb Python module is not available in Rhythmbox 2.99 anymore as the official upstream policy is to move to GObject introspected APIs completely
- the official Rhythmbox plugins have the same change in them: same method name in the RB pseudo-module and remove the dependency on rb
- see https://mail.gnome.org/archives/commits-list/2010-July/msg03902.html for upstream reference
