### PR TITLE
BUGFIX: updated Mobileclient.login() call

### DIFF
--- a/rhythmboxgmusic/__init__.py
+++ b/rhythmboxgmusic/__init__.py
@@ -236,7 +236,7 @@ class GooglePlayBaseSource(RB.Source):
         if mapi.is_authenticated():
             return True
         login, password = get_credentials()
-        return mapi.login(login, password)
+        return mapi.login(login, password, Mapi.FROM_MAC_ADDRESS)
 
     def auth(self, widget):
         dialog = AuthDialog()


### PR DESCRIPTION
- gmusicapi.Mobileclient.login() now requires an extra argument which contains the Android-ID of the device attempting the login. Used placeholder (since this will never be an Android device in real usage) as done in the example supplied with gmusicapi.
